### PR TITLE
Fixes #11 Authorize and capture with a saved card

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,21 +36,36 @@ $response->toArray(); // Returns array of attributes
 
 ## Authorizing Transactions
 ```php
-$authorization_response = $client->authorize([
+$request = new AuthorizationRequest([
     'account' => '4242424242424242',
     'amount'  => '100',
     'expiry'  => '0120',
 ]);
+$authorization_response = $client->authorize($request);
 ```
 
 **You can also authorize and capture in the same request like so**
 ```php
-$capture_response = $client->authorize([
+$request = new AuthorizationRequest([
     'account' => '4242424242424242',
     'amount'  => '100',
     'expiry'  => '0120',
-    'capture' => 'Y',
+    'capture' => 'Y', // OR 'capture' => true,
+    'profile' => 'Y', // OR 'profile' => true,
 ]);
+$capture_response = $client->authorize($request);
+```
+
+**You can also authorize and capture in the same request using a saved card with PROFILE_ID/ACCOUNT_ID like so**
+```php
+$request = new AuthorizationRequest([
+    'account' => '4242424242424242',
+    'amount'  => '100',
+    'expiry'  => '0120',
+    'capture' => 'Y', // OR 'capture' => true,
+    'profile' => "$profile_id/$account_id", // using a profile/account
+]);
+$capture_response = $client->authorize($request);
 ```
 
 To view all available fields see [Authorization Request](https://developer.cardconnect.com/cardconnect-api#authorization-request)

--- a/src/CardPointe.php
+++ b/src/CardPointe.php
@@ -170,7 +170,7 @@ class CardPointe
 
         $res = $this->parseResponse($res);
 
-        if ($request->capture) {
+        if ($request->capture && \in_array($request->capture, [true, 'Y', 'y'], true)) {
             return new CaptureResponse($res);
         }
 

--- a/src/Fluent.php
+++ b/src/Fluent.php
@@ -69,7 +69,11 @@ class Fluent implements ArrayAccess, JsonSerializable
 
         switch ($type) {
             case 'bool':
-                return (true === $thing) ? 'Y' : 'N';
+                if (is_bool($thing)) {
+                    return true === $thing ? 'Y' : 'N';
+                }
+                // Allows 'Y' and 'N' too.
+                return $thing;
                 break;
             default:
                 return $thing;


### PR DESCRIPTION
- Boolean values supported too **'Y'** / **'N'**.

**You can also authorize and capture in the same request using a saved card with PROFILE_ID/ACCOUNT_ID like so:**

```php
$request = new AuthorizationRequest([
    'account' => '4242424242424242',
    'amount'  => '100',
    'expiry'  => '0120',
    'capture' => 'Y', // OR 'capture' => true,
    'profile' => "$profile_id/$account_id", // using a profile/account
]);
$capture_response = $client->authorize($request);
```

- One more fix, if capture = 'N' was returning a CaptureResponse too.