### PR TITLE
Update version 2.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "dewbud/cardconnect",
     "description": "PHP adapter for CardConnect CardPointe API",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "keywords": [
         "cardconnect",
         "cardpointe"


### PR DESCRIPTION
Version 2.0.1 is not available.

[Tag 2.0.1](https://github.com/Dewbud/CardConnect/releases/tag/2.0.1) 
Fixes:
    - The requested package dewbud/cardconnect ^2.0.1 exists as dewbud/cardconnect[1.0.0, 1.0.1, 1.0.2, 1.1.0, 2.0.0, dev-dev, dev-master] but these are rejected by your constraint.
